### PR TITLE
WIP: Implement the wlr input inhibitor protocol

### DIFF
--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -15,6 +15,7 @@ wayland_scanner_client = generator(
 
 client_protocols = [
 	'xdg-shell.xml',
+	'wlr-input-inhibitor-unstable-v1.xml',
 ]
 
 client_protos_src = []

--- a/protocols/wlr-input-inhibitor-unstable-v1.xml
+++ b/protocols/wlr-input-inhibitor-unstable-v1.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_input_inhibit_unstable_v1">
+  <copyright>
+    Copyright © 2018 Drew DeVault
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_input_inhibit_manager_v1" version="1">
+    <description summary="inhibits input events to other clients">
+      Clients can use this interface to prevent input events from being sent to
+      any surfaces but its own, which is useful for example in lock screen
+      software. It is assumed that access to this interface will be locked down
+      to whitelisted clients by the compositor.
+    </description>
+
+    <request name="get_inhibitor">
+      <description summary="inhibit input to other clients">
+        Activates the input inhibitor. As long as the inhibitor is active, the
+        compositor will not send input events to other clients.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_input_inhibitor_v1"/>
+    </request>
+
+    <enum name="error">
+      <entry name="already_inhibited" value="0" summary="an input inhibitor is already in use on the compositor"/>
+    </enum>
+  </interface>
+
+  <interface name="zwlr_input_inhibitor_v1" version="1">
+    <description summary="inhibits input to other clients">
+      While this resource exists, input to clients other than the owner of the
+      inhibitor resource will not receive input events. Any client which
+      previously had focus will receive a leave event and will not be given
+      focus again. The client that owns this resource will receive all input
+      events normally. The compositor will also disable all of its own input
+      processing (such as keyboard shortcuts) while the inhibitor is active.
+
+      The compositor may continue to send input events to selected clients,
+      such as an on-screen keyboard (via the input-method protocol).
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the input inhibitor object">
+        Destroy the inhibitor and allow other clients to receive input.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,8 @@
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
 
+#include "wlr-input-inhibitor-unstable-v1.h"
+
 #include "pixman.h"
 #include "xdg-shell.h"
 #include "shm.h"
@@ -57,6 +59,8 @@ struct window {
 
 static struct wl_display* wl_display;
 static struct wl_registry* wl_registry;
+struct zwlr_input_inhibit_manager_v1 *input_inhibit_manager;
+struct zwlr_input_inhibitor_v1 * inhibitor;
 struct wl_compositor* wl_compositor = NULL;
 struct wl_shm* wl_shm = NULL;
 static struct xdg_wm_base* xdg_wm_base;
@@ -103,6 +107,8 @@ static void registry_add(void* data, struct wl_registry* registry, uint32_t id,
 		xdg_wm_base = wl_registry_bind(registry, id, &xdg_wm_base_interface, 1);
 	} else if (strcmp(interface, "wl_shm") == 0) {
 		wl_shm = wl_registry_bind(registry, id, &wl_shm_interface, 1);
+	} else if (strcmp(interface, zwlr_input_inhibit_manager_v1_interface.name) == 0) {
+		input_inhibit_manager = wl_registry_bind(registry, id, &zwlr_input_inhibit_manager_v1_interface, 1);
 	} else if (strcmp(interface, "wl_seat") == 0) {
 		struct wl_seat* wl_seat;
 		wl_seat = wl_registry_bind(registry, id, &wl_seat_interface, 5);
@@ -435,6 +441,23 @@ void on_keyboard_event(struct keyboard_collection* collection,
 
 	// TODO handle multiple symbols
 	xkb_keysym_t symbol = xkb_state_key_get_one_sym(keyboard->state, key);
+
+	if (symbol == XKB_KEY_F12) {
+		if (!is_pressed) {
+			if (inhibitor != NULL){
+				zwlr_input_inhibitor_v1_destroy(inhibitor);
+				inhibitor = NULL;
+			}
+			else {
+				inhibitor = zwlr_input_inhibit_manager_v1_get_inhibitor(input_inhibit_manager);
+			}
+		}
+		return;
+	}
+
+	if (inhibitor == NULL){
+		return;
+	}
 
 	char name[256];
 	xkb_keysym_get_name(symbol, name, sizeof(name));

--- a/src/pointer.c
+++ b/src/pointer.c
@@ -22,12 +22,16 @@
 #include <wayland-cursor.h>
 #include <linux/input-event-codes.h>
 
+#include "wlr-input-inhibitor-unstable-v1.h"
+
 #include "pointer.h"
 
 #define STEP_SIZE 15.0
 
 extern struct wl_shm* wl_shm;
 extern struct wl_compositor* wl_compositor;
+extern struct zwlr_input_inhibit_manager_v1 *input_inhibit_manager;
+extern struct zwlr_input_inhibitor_v1 * inhibitor;
 
 static struct wl_cursor_theme* pointer_load_cursor_theme(void)
 {
@@ -69,6 +73,11 @@ void pointer_destroy(struct pointer* self)
 	if (self->cursor_theme)
 		wl_cursor_theme_destroy(self->cursor_theme);
 	wl_surface_destroy(self->cursor_surface);
+	if (inhibitor != NULL){
+		zwlr_input_inhibit_manager_v1_destroy(input_inhibit_manager);
+		inhibitor=NULL;
+	}
+
 	free(self);
 }
 
@@ -162,6 +171,8 @@ static void pointer_enter(void* data, struct wl_pointer* wl_pointer,
 	pointer->serial = serial;
 
 	pointer_update_cursor(pointer);
+	if (inhibitor == NULL)
+		inhibitor = zwlr_input_inhibit_manager_v1_get_inhibitor(input_inhibit_manager);
 }
 
 static void pointer_leave(void* data, struct wl_pointer* wl_pointer,
@@ -174,7 +185,10 @@ static void pointer_leave(void* data, struct wl_pointer* wl_pointer,
 
 	pointer->serial = serial;
 
-	// Do nothing?
+	if (inhibitor != NULL){
+		zwlr_input_inhibitor_v1_destroy(inhibitor);
+		inhibitor = NULL;
+	}
 }
 
 static void pointer_motion(void* data, struct wl_pointer* wl_pointer,


### PR DESCRIPTION
There are a few things still to do:
* The inhibitor key acts like a toggle switch; you pressed it to toggle between inhibited and not inhibited
    * A behaviour like qemu or virtualbox where pressing the key only give you inputs back for 1 keypress seems more intuitive
* There is no way of knowing if the input is inhibited or not
    * some kind of indicator like updating the window title would help in that regard
* Making this magic key configurable is kinda important imo
* I wanted to use a modifier with the key but it's my first time using libxkbcommon, so I haven't figured that out yet 🙃

Also, keep in mind I have not implemented a wayland protocol before, so I did my best to follow what I thought the protocol said, and as it is quite a simple one, I hope I didn't screw it up to bad.