### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/src/vnc.c
+++ b/src/vnc.c
@@ -24,7 +24,6 @@
 #include <rfb/rfbclient.h>
 #include <libdrm/drm_fourcc.h>
 #include <libavutil/frame.h>
-#include <byteswap.h>
 
 #include "vnc.h"
 #include "open-h264.h"
@@ -42,7 +41,7 @@ rfbBool vnc_client_set_format_and_encodings(rfbClient* client);
 static uint64_t vnc_client_htonll(uint64_t x)
 {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-	return bswap_64(x);
+	return __builtin_bswap64(x);
 #else
 	return x;
 #endif


### PR DESCRIPTION
`<byteswap.h>` is a GNU header (also adopted by bionic, musl) and doesn't exist in POSIX or on FreeBSD, NetBSD, OpenBSD. On DragonFly, FreeBSD, NetBSD `<sys/endian.h>` provides `bswap64` (without `_` interfix) while OpenBSD provides `swap64` (without `b` prefix and without `_` interfix).

See also https://github.com/DragonFlyBSD/DragonFlyBSD/commit/c7e47104c46f and https://reviews.freebsd.org/D32051

```
$ cc --version
FreeBSD clang version 13.0.0 (git@github.com:llvm/llvm-project.git llvmorg-13.0.0-0-gd7b669b3a303)
Target: x86_64-unknown-freebsd14.0
Thread model: posix
InstalledDir: /usr/bin

$ cc -dM -E -</dev/null | fgrep ORDER
#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
#define __ORDER_BIG_ENDIAN__ 4321
#define __ORDER_LITTLE_ENDIAN__ 1234
#define __ORDER_PDP_ENDIAN__ 3412
```
