### PR TITLE
meson: unbreak when libjpeg isn't found

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -80,7 +80,6 @@ sources = [
 	'src/rfbproto.c',
 	'src/sockets.c',
 	'src/vncviewer.c',
-	'src/turbojpeg.c',
 ]
 
 dependencies = [
@@ -133,6 +132,7 @@ if sasl.found()
 endif
 
 if libjpeg.found()
+	sources += 'src/turbojpeg.c'
 	dependencies += libjpeg
 	config.set('LIBVNCSERVER_HAVE_LIBJPEG', true)
 endif


### PR DESCRIPTION
```c
$ meson setup /tmp/wlvncc_build
$ meson compile -C /tmp/wlvncc_build
[...]
FAILED: wlvncc
cc  -o wlvncc wlvncc.p/src_main.c.o wlvncc.p/src_shm.c.o wlvncc.p/src_seat.c.o wlvncc.p/src_pointer.c.o wlvncc.p/src_keyboard.c.o wlvncc.p/src_vnc.c.o wlvncc.p/src_strlcpy.c.o wlvncc.p/src_evdev-to-qnum.c.o wlvncc.p/src_pixels.c.o wlvncc.p/src_region.c.o wlvncc.p/src_renderer.c.o wlvncc.p/src_renderer-egl.c.o wlvncc.p/src_buffer.c.o wlvncc.p/src_open-h264.c.o wlvncc.p/src_cursor.c.o wlvncc.p/src_rfbproto.c.o wlvncc.p/src_sockets.c.o wlvncc.p/src_vncviewer.c.o wlvncc.p/src_turbojpeg.c.o wlvncc.p/src_crypto_openssl.c.o wlvncc.p/src_tls_openssl.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,-rpath,/usr/local/lib -Wl,-rpath-link,/usr/local/lib -Wl,--start-group protocols/libclient_protos.a -lm -lrt /usr/local/lib/libxkbcommon.so /usr/local/lib/libpixman-1.so /usr/local/lib/libaml.so /usr/local/lib/libwayland-client.so /usr/local/lib/libwayland-cursor.so /usr/local/lib/libdrm.so /usr/local/lib/libgbm.so /usr/local/lib/libEGL.so /usr/local/lib/libGLESv2.so /usr/local/lib/libavcodec.so /usr/local/lib/libavutil.so -lssl -lcrypto /usr/local/lib/libpng16.so /usr/lib/libz.so -lpthread /usr/local/lib/liblzo2.so -Wl,--end-group
ld: error: undefined symbol: jpeg_destroy_compress
>>> referenced by turbojpeg.c:442 (src/turbojpeg.c:442)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjDestroy)

ld: error: undefined symbol: jpeg_destroy_decompress
>>> referenced by turbojpeg.c:443 (src/turbojpeg.c:443)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjDestroy)

ld: error: undefined symbol: jpeg_std_error
>>> referenced by turbojpeg.c:464 (src/turbojpeg.c:464)
>>>               wlvncc.p/src_turbojpeg.c.o:(_tjInitCompress)
>>> referenced by turbojpeg.c:649 (src/turbojpeg.c:649)
>>>               wlvncc.p/src_turbojpeg.c.o:(_tjInitDecompress)

ld: error: undefined symbol: jpeg_CreateCompress
>>> referenced by turbojpeg.c:475 (src/turbojpeg.c:475)
>>>               wlvncc.p/src_turbojpeg.c.o:(_tjInitCompress)

ld: error: undefined symbol: jpeg_start_compress
>>> referenced by turbojpeg.c:589 (src/turbojpeg.c:589)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjCompress2)

ld: error: undefined symbol: jpeg_write_scanlines
>>> referenced by turbojpeg.c:599 (src/turbojpeg.c:599)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjCompress2)

ld: error: undefined symbol: jpeg_finish_compress
>>> referenced by turbojpeg.c:602 (src/turbojpeg.c:602)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjCompress2)

ld: error: undefined symbol: jpeg_abort_compress
>>> referenced by turbojpeg.c:607 (src/turbojpeg.c:607)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjCompress2)

ld: error: undefined symbol: jpeg_set_defaults
>>> referenced by turbojpeg.c:183 (src/turbojpeg.c:183)
>>>               wlvncc.p/src_turbojpeg.c.o:(setCompDefaults)

ld: error: undefined symbol: jpeg_set_quality
>>> referenced by turbojpeg.c:186 (src/turbojpeg.c:186)
>>>               wlvncc.p/src_turbojpeg.c.o:(setCompDefaults)

ld: error: undefined symbol: jpeg_set_colorspace
>>> referenced by turbojpeg.c:191 (src/turbojpeg.c:191)
>>>               wlvncc.p/src_turbojpeg.c.o:(setCompDefaults)
>>> referenced by turbojpeg.c:193 (src/turbojpeg.c:193)
>>>               wlvncc.p/src_turbojpeg.c.o:(setCompDefaults)

ld: error: undefined symbol: jpeg_CreateDecompress
>>> referenced by turbojpeg.c:660 (src/turbojpeg.c:660)
>>>               wlvncc.p/src_turbojpeg.c.o:(_tjInitDecompress)

ld: error: undefined symbol: jpeg_resync_to_restart
>>> referenced by turbojpeg.c:665 (src/turbojpeg.c:665)
>>>               wlvncc.p/src_turbojpeg.c.o:(_tjInitDecompress)

ld: error: undefined symbol: jpeg_read_header
>>> referenced by turbojpeg.c:708 (src/turbojpeg.c:708)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjDecompressHeader2)
>>> referenced by turbojpeg.c:780 (src/turbojpeg.c:780)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjDecompress2)

ld: error: undefined symbol: jpeg_abort_decompress
>>> referenced by turbojpeg.c:714 (src/turbojpeg.c:714)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjDecompressHeader2)
>>> referenced by turbojpeg.c:844 (src/turbojpeg.c:844)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjDecompress2)

ld: error: undefined symbol: jpeg_start_decompress
>>> referenced by turbojpeg.c:806 (src/turbojpeg.c:806)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjDecompress2)

ld: error: undefined symbol: jpeg_read_scanlines
>>> referenced by turbojpeg.c:834 (src/turbojpeg.c:834)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjDecompress2)

ld: error: undefined symbol: jpeg_finish_decompress
>>> referenced by turbojpeg.c:837 (src/turbojpeg.c:837)
>>>               wlvncc.p/src_turbojpeg.c.o:(tjDecompress2)
cc: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```
