### PR TITLE
fix issue with horizontal scrolling

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -461,14 +461,14 @@ void on_pointer_event(struct pointer_collection* collection,
 	if (vertical_steps < 0) {
 		vertical_steps *= -1;
 		scroll_mask |= POINTER_SCROLL_UP;
-	} else {
+	} else if (vertical_steps > 0) {
 		scroll_mask |= POINTER_SCROLL_DOWN;
 	}
 
 	if (horizontal_steps < 0) {
 		horizontal_steps *= -1;
 		scroll_mask |= POINTER_SCROLL_LEFT;
-	} else {
+	} else if (horizontal_steps > 0) {
 		scroll_mask |= POINTER_SCROLL_RIGHT;
 	}
 


### PR DESCRIPTION
scrolling horizontally left or right would both also contribute to scrolling downward, probably due to a bitwise math bug. there's likely a much simpler change to the existing code to fix it, but I tried to understand what it did and rewrite it because it was easier.   
personally, I do not use/want horizontal scrolling, but my trackball/trackpoint devices make it difficult to scroll directly up/down without also having some sideways movement.  
purely to test if horizontal scrolling worked, I hacked in support for it in wayvnc using the following, and it does function when used along with this PR.  
```diff
diff --git a/src/pointer.c b/src/pointer.c
index 3e33b68..443e1dc 100644
--- a/src/pointer.c
+++ b/src/pointer.c
@@ -51,6 +51,7 @@ static void pointer_set_button_mask(struct pointer* self, uint32_t t,
                                               !!(mask & NVNC_BUTTON_RIGHT));
 
        int axis = WL_POINTER_AXIS_VERTICAL_SCROLL;
+       int axis2 = WL_POINTER_AXIS_HORIZONTAL_SCROLL;
 
        /* I arrived at the magical value of 15 by connecting a mouse with a
         * scroll wheel and viewing the output of wev.
@@ -65,6 +66,16 @@ static void pointer_set_button_mask(struct pointer* self, uint32_t t,
                zwlr_virtual_pointer_v1_axis_discrete(self->pointer, t, axis,
                                                      wl_fixed_from_int(15),
                                                      1);
+       
+       if ((diff & (1 << 5)) && !(mask & (1 << 5)))
+               zwlr_virtual_pointer_v1_axis_discrete(self->pointer, t, axis2,
+                                                     wl_fixed_from_int(-15),
+                                                     -1);
+
+       if ((diff & (1 << 6)) && !(mask & (1 << 6)))
+               zwlr_virtual_pointer_v1_axis_discrete(self->pointer, t, axis2,
+                                                     wl_fixed_from_int(15),
+ 
```