### PR TITLE
Add support for rfbEncodingDesktopSize

### DIFF
--- a/include/rfbclient.h
+++ b/include/rfbclient.h
@@ -330,8 +330,6 @@ typedef struct _rfbClient {
 	int KeyboardLedStateEnabled;
 	int CurrentKeyboardLedState;
 
-	int canHandleNewFBSize;
-
 	/* hooks */
 	HandleTextChatProc         HandleTextChat;
 	HandleKeyboardLedStateProc HandleKeyboardLedState;

--- a/include/rfbproto.h
+++ b/include/rfbproto.h
@@ -475,7 +475,7 @@ typedef struct {
 #define rfbEncodingPointerPos      0xFFFFFF18
 
 #define rfbEncodingLastRect           0xFFFFFF20
-#define rfbEncodingNewFBSize          0xFFFFFF21
+#define rfbEncodingDesktopSize        0xFFFFFF21
 #define rfbEncodingExtDesktopSize     0xFFFFFECC
 
 #define rfbEncodingQualityLevel0   0xFFFFFFE0

--- a/src/rfbproto.c
+++ b/src/rfbproto.c
@@ -1391,7 +1391,7 @@ rfbBool SetFormatAndEncodings(rfbClient* client)
 		        rfbClientSwap32IfLE(rfbEncodingKeyboardLedState);
 
 	/* New Frame Buffer Size */
-	if (se->nEncodings < MAX_ENCODINGS && client->canHandleNewFBSize)
+	if (se->nEncodings < MAX_ENCODINGS)
 		encs[se->nEncodings++] =
 		        rfbClientSwap32IfLE(rfbEncodingNewFBSize);
 

--- a/src/rfbproto.c
+++ b/src/rfbproto.c
@@ -1390,10 +1390,10 @@ rfbBool SetFormatAndEncodings(rfbClient* client)
 		encs[se->nEncodings++] =
 		        rfbClientSwap32IfLE(rfbEncodingKeyboardLedState);
 
-	/* New Frame Buffer Size */
+	/* New Desktop Size */
 	if (se->nEncodings < MAX_ENCODINGS)
 		encs[se->nEncodings++] =
-		        rfbClientSwap32IfLE(rfbEncodingNewFBSize);
+		        rfbClientSwap32IfLE(rfbEncodingDesktopSize);
 
 	/* Last Rect */
 	if (se->nEncodings < MAX_ENCODINGS && requestLastRectEncoding)
@@ -1826,7 +1826,7 @@ static rfbBool HandleFramebufferUpdate(rfbClient* client,
 			continue;
 		}
 
-		if (rect.encoding == rfbEncodingNewFBSize) {
+		if (rect.encoding == rfbEncodingDesktopSize) {
 			if (!ResizeClientBuffer(client, rect.r.w, rect.r.h))
 				goto failure;
 			SendFramebufferUpdateRequest(client, 0, 0, rect.r.w,


### PR DESCRIPTION
wlvncc already have code to handle new frame buffer size.

However, since rfbEncodingDesktopSize capability is not set, server won't send rfbEncodingNewFBSize messages.