### PR TITLE
Implement the keyboard shortcuts inhibitor protocol

### DIFF
--- a/include/inhibitor.h
+++ b/include/inhibitor.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <stdbool.h>
+#include "seat.h"
+
+#include "keyboard-shortcuts-inhibit-unstable-v1.h"
+
+struct shortcuts_inhibitor {
+	//TODO add the inhibitor toggle key to the struct ?
+	struct zwp_keyboard_shortcuts_inhibit_manager_v1* manager;
+
+	struct wl_surface* surface;
+	struct wl_list seat_inhibitors;
+};
+
+struct shortcuts_seat_inhibitor {
+	struct wl_list link;
+
+	struct seat* seat;
+
+	struct zwp_keyboard_shortcuts_inhibitor_v1* inhibitor;
+};
+
+struct shortcuts_inhibitor* inhibitor_new(struct zwp_keyboard_shortcuts_inhibit_manager_v1*);
+struct shortcuts_seat_inhibitor* seat_inhibitor_find_by_seat(struct wl_list*, struct seat*);
+void inhibitor_destroy(struct shortcuts_inhibitor*);
+bool inhibitor_init(struct shortcuts_inhibitor*, struct wl_surface*, struct wl_list*);
+void inhibitor_add_seat(struct shortcuts_inhibitor*, struct seat*);
+void inhibitor_remove_seat(struct shortcuts_inhibitor*, struct seat*);
+
+bool inhibitor_is_inhibited(struct shortcuts_inhibitor*, struct seat* seat);
+void inhibitor_inhibit(struct shortcuts_inhibitor*, struct seat* seat);
+void inhibitor_release(struct shortcuts_inhibitor*, struct seat* seat);
+void inhibitor_toggle(struct shortcuts_inhibitor*, struct seat* seat);

--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -30,6 +30,8 @@ struct keyboard {
 	struct wl_keyboard* wl_keyboard;
 	struct wl_list link;
 
+	struct seat* seat;
+
 	struct xkb_context* context;
 	struct xkb_keymap* keymap;
 	struct xkb_state* state;
@@ -51,6 +53,6 @@ struct keyboard_collection* keyboard_collection_new(void);
 void keyboard_collection_destroy(struct keyboard_collection*);
 
 int keyboard_collection_add_wl_keyboard(struct keyboard_collection* self,
-		struct wl_keyboard* wl_keyboard);
+		struct wl_keyboard* wl_keyboard, struct seat* seat);
 void keyboard_collection_remove_wl_keyboard(struct keyboard_collection* self,
 		struct wl_keyboard* wl_keyboard);

--- a/include/pointer.h
+++ b/include/pointer.h
@@ -40,6 +40,8 @@ struct pointer {
 	struct wl_pointer* wl_pointer;
 	struct wl_list link;
 
+	struct seat* seat;
+
 	uint32_t serial;
 	enum pointer_button_mask pressed;
 	wl_fixed_t x, y;
@@ -67,6 +69,6 @@ struct pointer_collection* pointer_collection_new(enum pointer_cursor_type);
 void pointer_collection_destroy(struct pointer_collection*);
 
 int pointer_collection_add_wl_pointer(struct pointer_collection* self,
-		struct wl_pointer* wl_pointer);
+		struct wl_pointer* wl_pointer, struct seat*);
 void pointer_collection_remove_wl_pointer(struct pointer_collection* self,
 		struct wl_pointer* wl_pointer);

--- a/meson.build
+++ b/meson.build
@@ -82,6 +82,7 @@ sources = [
 	'src/rfbproto.c',
 	'src/sockets.c',
 	'src/vncviewer.c',
+	'src/inhibitor.c',
 ]
 
 dependencies = [

--- a/protocols/keyboard-shortcuts-inhibit-unstable-v1.xml
+++ b/protocols/keyboard-shortcuts-inhibit-unstable-v1.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="keyboard_shortcuts_inhibit_unstable_v1">
+
+  <copyright>
+    Copyright © 2017 Red Hat Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol for inhibiting the compositor keyboard shortcuts">
+    This protocol specifies a way for a client to request the compositor
+    to ignore its own keyboard shortcuts for a given seat, so that all
+    key events from that seat get forwarded to a surface.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible
+    changes may be added together with the corresponding interface
+    version bump.
+    Backward incompatible changes are done by bumping the version
+    number in the protocol and interface names and resetting the
+    interface version. Once the protocol is to be declared stable,
+    the 'z' prefix and the version number in the protocol and
+    interface names are removed and the interface version number is
+    reset.
+  </description>
+
+  <interface name="zwp_keyboard_shortcuts_inhibit_manager_v1" version="1">
+    <description summary="context object for keyboard grab_manager">
+      A global interface used for inhibiting the compositor keyboard shortcuts.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the keyboard shortcuts inhibitor object">
+	Destroy the keyboard shortcuts inhibitor manager.
+      </description>
+    </request>
+
+    <request name="inhibit_shortcuts">
+      <description summary="create a new keyboard shortcuts inhibitor object">
+	Create a new keyboard shortcuts inhibitor object associated with
+	the given surface for the given seat.
+
+	If shortcuts are already inhibited for the specified seat and surface,
+	a protocol error "already_inhibited" is raised by the compositor.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_keyboard_shortcuts_inhibitor_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"
+	   summary="the surface that inhibits the keyboard shortcuts behavior"/>
+      <arg name="seat" type="object" interface="wl_seat"
+	   summary="the wl_seat for which keyboard shortcuts should be disabled"/>
+    </request>
+
+    <enum name="error">
+      <entry name="already_inhibited"
+	     value="0"
+	     summary="the shortcuts are already inhibited for this surface"/>
+    </enum>
+  </interface>
+
+  <interface name="zwp_keyboard_shortcuts_inhibitor_v1" version="1">
+    <description summary="context object for keyboard shortcuts inhibitor">
+      A keyboard shortcuts inhibitor instructs the compositor to ignore
+      its own keyboard shortcuts when the associated surface has keyboard
+      focus. As a result, when the surface has keyboard focus on the given
+      seat, it will receive all key events originating from the specified
+      seat, even those which would normally be caught by the compositor for
+      its own shortcuts.
+
+      The Wayland compositor is however under no obligation to disable
+      all of its shortcuts, and may keep some special key combo for its own
+      use, including but not limited to one allowing the user to forcibly
+      restore normal keyboard events routing in the case of an unwilling
+      client. The compositor may also use the same key combo to reactivate
+      an existing shortcut inhibitor that was previously deactivated on
+      user request.
+
+      When the compositor restores its own keyboard shortcuts, an
+      "inactive" event is emitted to notify the client that the keyboard
+      shortcuts inhibitor is not effectively active for the surface and
+      seat any more, and the client should not expect to receive all
+      keyboard events.
+
+      When the keyboard shortcuts inhibitor is inactive, the client has
+      no way to forcibly reactivate the keyboard shortcuts inhibitor.
+
+      The user can chose to re-enable a previously deactivated keyboard
+      shortcuts inhibitor using any mechanism the compositor may offer,
+      in which case the compositor will send an "active" event to notify
+      the client.
+
+      If the surface is destroyed, unmapped, or loses the seat's keyboard
+      focus, the keyboard shortcuts inhibitor becomes irrelevant and the
+      compositor will restore its own keyboard shortcuts but no "inactive"
+      event is emitted in this case.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the keyboard shortcuts inhibitor object">
+	Remove the keyboard shortcuts inhibitor from the associated wl_surface.
+      </description>
+    </request>
+
+    <event name="active">
+      <description summary="shortcuts are inhibited">
+	This event indicates that the shortcut inhibitor is active.
+
+	The compositor sends this event every time compositor shortcuts
+	are inhibited on behalf of the surface. When active, the client
+	may receive input events normally reserved by the compositor
+	(see zwp_keyboard_shortcuts_inhibitor_v1).
+
+	This occurs typically when the initial request "inhibit_shortcuts"
+	first becomes active or when the user instructs the compositor to
+	re-enable and existing shortcuts inhibitor using any mechanism
+	offered by the compositor.
+      </description>
+    </event>
+
+    <event name="inactive">
+      <description summary="shortcuts are restored">
+	This event indicates that the shortcuts inhibitor is inactive,
+	normal shortcuts processing is restored by the compositor.
+       </description>
+    </event>
+  </interface>
+</protocol>

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -16,6 +16,7 @@ wayland_scanner_client = generator(
 client_protocols = [
 	'xdg-shell.xml',
 	'linux-dmabuf-v1.xml',
+	'keyboard-shortcuts-inhibit-unstable-v1.xml',
 ]
 
 client_protos_src = []

--- a/src/inhibitor.c
+++ b/src/inhibitor.c
@@ -1,0 +1,166 @@
+#include <stdlib.h>
+
+#include "inhibitor.h"
+#include "seat.h"
+#include <stdio.h>
+#include <wayland-client.h>
+#include <assert.h>
+
+struct shortcuts_inhibitor* inhibitor_new(struct zwp_keyboard_shortcuts_inhibit_manager_v1* manager)
+{
+	struct shortcuts_inhibitor* self = calloc(1, sizeof(*self));
+	if (!self)
+		return NULL;
+
+	self->manager = manager;
+	self->surface = NULL;
+	wl_list_init(&self->seat_inhibitors);
+
+	return self;
+}
+
+struct shortcuts_seat_inhibitor* seat_inhibitor_new(struct seat* seat)
+{
+	struct shortcuts_seat_inhibitor* self = calloc(1, sizeof(*self));
+	if (!self)
+		return NULL;
+
+	self->seat = seat;
+	self->inhibitor = NULL;
+
+	return self;
+}
+
+struct shortcuts_seat_inhibitor* seat_inhibitor_find_by_seat(struct wl_list* list, struct seat* seat)
+{
+	struct shortcuts_seat_inhibitor* seat_inhibitor;
+
+	wl_list_for_each(seat_inhibitor, list, link) {
+		if (seat == seat_inhibitor->seat) {
+			return seat_inhibitor;
+		}
+	}
+
+	return NULL;
+}
+
+bool inhibitor_init(struct shortcuts_inhibitor* self, struct wl_surface* surface,
+		struct wl_list* seats)
+{
+	if (!self)
+		return false;
+	if (self->surface)
+		return false;
+
+	self->surface = surface;
+
+	struct seat* seat;
+	struct seat* tmp;
+
+	wl_list_for_each_safe(seat, tmp, seats, link)
+		inhibitor_add_seat(self, seat);
+
+	return true;
+}
+
+void seat_inhibitor_destroy(struct shortcuts_seat_inhibitor* self)
+{
+	if (!self)
+		return;
+
+	if (self->inhibitor)
+		zwp_keyboard_shortcuts_inhibitor_v1_destroy(self->inhibitor);
+	free(self);
+}
+
+void inhibitor_destroy(struct shortcuts_inhibitor* self)
+{
+	if (!self)
+		return;
+
+	struct shortcuts_seat_inhibitor* seat_inhibitor;
+	struct shortcuts_seat_inhibitor* tmp;
+
+	wl_list_for_each_safe(seat_inhibitor, tmp, &self->seat_inhibitors, link)
+		seat_inhibitor_destroy(seat_inhibitor);
+	zwp_keyboard_shortcuts_inhibit_manager_v1_destroy(self->manager);
+	free(self);
+}
+
+bool inhibitor_is_inhibited(struct shortcuts_inhibitor* self,
+		struct seat* seat)
+{
+	if (!self)
+		return false;
+
+	struct shortcuts_seat_inhibitor* seat_inhibitor = seat_inhibitor_find_by_seat(&self->seat_inhibitors, seat);
+	assert(seat_inhibitor);
+
+	return seat_inhibitor->inhibitor != NULL;
+}
+
+void inhibitor_inhibit(struct shortcuts_inhibitor* self, struct seat* seat)
+{
+	if (!self)
+		return;
+	if (inhibitor_is_inhibited(self, seat))
+		return;
+
+	struct shortcuts_seat_inhibitor* seat_inhibitor = seat_inhibitor_find_by_seat(&self->seat_inhibitors, seat);
+	assert(seat_inhibitor);
+
+	seat_inhibitor->inhibitor = zwp_keyboard_shortcuts_inhibit_manager_v1_inhibit_shortcuts(
+			self->manager, self->surface, seat_inhibitor->seat->wl_seat);
+}
+
+void inhibitor_release(struct shortcuts_inhibitor* self, struct seat* seat)
+{
+	if (!self)
+		return;
+	if (!inhibitor_is_inhibited(self, seat))
+		return;
+
+	struct shortcuts_seat_inhibitor* seat_inhibitor = seat_inhibitor_find_by_seat(&self->seat_inhibitors, seat);
+	assert(seat_inhibitor);
+
+	zwp_keyboard_shortcuts_inhibitor_v1_destroy(seat_inhibitor->inhibitor);
+	seat_inhibitor->inhibitor = NULL;
+}
+
+void inhibitor_toggle(struct shortcuts_inhibitor* self, struct seat* seat)
+{
+	if (!self)
+		return;
+
+	if (inhibitor_is_inhibited(self, seat)) {
+		inhibitor_release(self, seat);
+	} else {
+		inhibitor_inhibit(self, seat);
+	}
+}
+
+void inhibitor_add_seat(struct shortcuts_inhibitor* self, struct seat* seat)
+{
+	if (!self)
+		return;
+
+	struct shortcuts_seat_inhibitor* seat_inhibitor = seat_inhibitor_find_by_seat(&self->seat_inhibitors, seat);
+	if (seat_inhibitor)
+		return;
+
+	seat_inhibitor = seat_inhibitor_new(seat);
+	wl_list_insert(&self->seat_inhibitors, &seat_inhibitor->link);
+}
+
+void inhibitor_remove_seat(struct shortcuts_inhibitor* self, struct seat* seat)
+{
+	if (!self)
+		return;
+
+	struct shortcuts_seat_inhibitor* seat_inhibitor = seat_inhibitor_find_by_seat(&self->seat_inhibitors, seat);
+	if (!seat_inhibitor)
+		return;
+
+	wl_list_remove(&seat_inhibitor->link);
+	seat_inhibitor_destroy(seat_inhibitor);
+}

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -31,13 +31,15 @@ enum keyboard_led_state {
 	KEYBOARD_LED_CAPS_LOCK = 1 << 2,
 };
 
-struct keyboard* keyboard_new(struct wl_keyboard* wl_keyboard)
+struct keyboard* keyboard_new(struct wl_keyboard* wl_keyboard,
+		struct seat* seat)
 {
 	struct keyboard* self = calloc(1, sizeof(*self));
 	if (!self)
 		return NULL;
 
 	self->wl_keyboard = wl_keyboard;
+	self->seat = seat;
 	self->context = xkb_context_new(0);
 
 	return self;
@@ -230,9 +232,9 @@ static struct wl_keyboard_listener keyboard_listener = {
 };
 
 int keyboard_collection_add_wl_keyboard(struct keyboard_collection* self,
-		struct wl_keyboard* wl_keyboard)
+		struct wl_keyboard* wl_keyboard, struct seat* seat)
 {
-	struct keyboard* keyboard = keyboard_new(wl_keyboard);
+	struct keyboard* keyboard = keyboard_new(wl_keyboard, seat);
 	if (!keyboard)
 		return -1;
 

--- a/src/main.c
+++ b/src/main.c
@@ -102,6 +102,7 @@ static uint64_t last_canary_tick;
 struct shortcuts_inhibitor* inhibitor;
 
 static bool have_egl = false;
+static bool shortcut_inhibit = false;
 
 static uint32_t shm_format = DRM_FORMAT_INVALID;
 static uint32_t dmabuf_format = DRM_FORMAT_INVALID;
@@ -149,6 +150,8 @@ static void registry_add(void* data, struct wl_registry* registry, uint32_t id,
 		zwp_linux_dmabuf_v1 = wl_registry_bind(registry, id,
 				&zwp_linux_dmabuf_v1_interface, 4);
 	} else if (strcmp(interface, zwp_keyboard_shortcuts_inhibit_manager_v1_interface.name) == 0) {
+		if (!shortcut_inhibit)
+			return;
 		keyboard_shortcuts_inhibitor = wl_registry_bind(registry, id,
 				&zwp_keyboard_shortcuts_inhibit_manager_v1_interface, 1);
 		inhibitor = inhibitor_new(keyboard_shortcuts_inhibitor);
@@ -951,6 +954,7 @@ Usage: wlvncc <address> [port]\n\
                              hextile, zlib, corre, rre, raw, open-h264.\n\
     -h,--help                Get help.\n\
     -n,--hide-cursor         Hide the client-side cursor.\n\
+    -i,--shortcut-inhibit    Enable the shortcut inhibitor while being focused.\n\
     -q,--quality             Quality level (0 - 9).\n\
     -t,--tls-cert            Use given TLS cert for authenticating server.\n\
     -s,--use-sw-renderer     Use software rendering.\n\
@@ -967,7 +971,7 @@ int main(int argc, char* argv[])
 	const char* encodings = NULL;
 	int quality = -1;
 	int compression = -1;
-	static const char* shortopts = "a:A:q:c:e:hnst:";
+	static const char* shortopts = "a:A:q:c:e:hnist:";
 	bool use_sw_renderer = false;
 
 	static const struct option longopts[] = {
@@ -976,6 +980,7 @@ int main(int argc, char* argv[])
 		{ "compression", required_argument, NULL, 'c' },
 		{ "encodings", required_argument, NULL, 'e' },
 		{ "hide-cursor", no_argument, NULL, 'n' },
+		{ "shortcut-inhibit", no_argument, NULL, 'i' },
 		{ "help", no_argument, NULL, 'h' },
 		{ "quality", required_argument, NULL, 'q' },
 		{ "tls-cert", required_argument, NULL, 't' },
@@ -1006,6 +1011,9 @@ int main(int argc, char* argv[])
 			break;
 		case 'n':
 			cursor_type = POINTER_CURSOR_NONE;
+			break;
+		case 'i':
+			shortcut_inhibit = true;
 			break;
 		case 's':
 			use_sw_renderer = true;


### PR DESCRIPTION
This is a continuation of: https://github.com/any1/wlvncc/pull/5

I got good Wayland knowledge, I should be able to tackle on remaining issues, if there are.

~~For now I just rebased this over master, fixed conflicts, and compiled. It works so far, and use the most recent protocol.~~

I rebased this over master, and adapted it to handle multiple seat correctly. We inhibit shortcuts only for the seats with a pointer in the surface.