### PR TITLE
De-duplicate mouse scroll events

### DIFF
--- a/src/pointer.c
+++ b/src/pointer.c
@@ -260,19 +260,7 @@ static void pointer_axis_stop(void* data, struct wl_pointer* wl_pointer,
 static void pointer_axis_discrete(void* data, struct wl_pointer* wl_pointer,
 		enum wl_pointer_axis axis, int steps)
 {
-	struct pointer_collection* self = data;
-	struct pointer* pointer =
-		pointer_collection_find_wl_pointer(self, wl_pointer);
-
-	switch (axis) {
-	case WL_POINTER_AXIS_VERTICAL_SCROLL:
-		pointer->vertical_scroll_steps += steps;
-		break;
-	case WL_POINTER_AXIS_HORIZONTAL_SCROLL:
-		pointer->horizontal_scroll_steps += steps;
-		break;
-	default:;
-	}
+	// Deprecated
 }
 
 static void pointer_frame(void* data, struct wl_pointer* wl_pointer)


### PR DESCRIPTION
This bug is caused by a deprecated pointer event pointer::axis_discrete.

This event is received additionaly to pointer::axis, and we add them together. Meaning one scroll event, with a STEP 15, plus a discrete step, equal to two event that we will sent to the VNC server.

pointer::axis_discrete is deprecated as version 8, and is always coupled with pointer::axis. Also, it is not sent by touchpad scrolls.

https://wayland.app/protocols/wayland#wl_pointer:event:axis_discrete

We can safely ignore it.

fixes: https://github.com/any1/wlvncc/issues/43