### PR TITLE
Fix keyboard events when shortcut_inhibitor is disabled

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -690,10 +690,6 @@ void on_keyboard_event(struct keyboard_collection* collection,
 		return;
 	}
 
-	if (!inhibitor_is_inhibited(inhibitor, keyboard->seat)) {
-		return;
-	}
-
 	char name[256];
 	xkb_keysym_get_name(symbol, name, sizeof(name));
 


### PR DESCRIPTION
In case shortcut_inhibitor is enabled:
This fixes keyboard events when the window is focused, but the pointer hasn't entered the window.