### PR TITLE
Make the shortcut inhibitor to works on the bg surface too

### DIFF
--- a/src/pointer.c
+++ b/src/pointer.c
@@ -164,6 +164,8 @@ static void pointer_enter(void* data, struct wl_pointer* wl_pointer,
 		pointer_collection_find_wl_pointer(self, wl_pointer);
 	assert(pointer);
 
+	inhibitor_inhibit(inhibitor, pointer->seat);
+
 	pointer->handle_event = self->handle_event(surface);
 	if (!pointer->handle_event)
 		return;
@@ -171,7 +173,6 @@ static void pointer_enter(void* data, struct wl_pointer* wl_pointer,
 	pointer->serial = serial;
 
 	pointer_update_cursor(pointer);
-	inhibitor_inhibit(inhibitor, pointer->seat);
 }
 
 static void pointer_leave(void* data, struct wl_pointer* wl_pointer,
@@ -182,12 +183,13 @@ static void pointer_leave(void* data, struct wl_pointer* wl_pointer,
 		pointer_collection_find_wl_pointer(self, wl_pointer);
 	assert(pointer);
 
+	inhibitor_release(inhibitor, pointer->seat);
+
 	pointer->handle_event = self->handle_event(surface);
 	if (!pointer->handle_event)
 		return;
 
 	pointer->serial = serial;
-	inhibitor_release(inhibitor, pointer->seat);
 }
 
 static void pointer_motion(void* data, struct wl_pointer* wl_pointer,


### PR DESCRIPTION
The fact it works on the internal surface, but not on the bg surface is a really confusing behavior. It can really feels like it is bugged, in case some of the internal buffer is also black (example looking at a video with an aspect ratio not fitting in the display).

On the first place, I did this because I thought we had to because of the F12 toggle key. But this toggle also is triggerable on the bg surface so.

I am even thinking we should inhibit on keyboard.enter too. Okay it would technically mean traping users that are using keyboard based windows manager, as Sway. But in the same time, if those users wants to switch a workspace remotely, atm they have to grab their mouse, focus wlvncc, then use their keyboard.