### PR TITLE
Respect the compositor shortcut inhibitor activations/inactivations

### DIFF
--- a/include/inhibitor.h
+++ b/include/inhibitor.h
@@ -17,6 +17,7 @@ struct shortcuts_seat_inhibitor {
 	struct wl_list link;
 
 	struct seat* seat;
+	bool active;
 
 	struct zwp_keyboard_shortcuts_inhibitor_v1* inhibitor;
 };

--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -26,6 +26,11 @@ struct xkb_state;
 
 struct keyboard_collection;
 
+struct pressed_key {
+	uint32_t key;
+	struct wl_list link;
+};
+
 struct keyboard {
 	struct wl_keyboard* wl_keyboard;
 	struct wl_list link;
@@ -38,6 +43,8 @@ struct keyboard {
 
 	struct keyboard_collection* collection;
 	uint32_t led_state;
+
+	struct wl_list pressed_keys;
 
 	bool waiting_for_modifiers;
 };

--- a/src/inhibitor.c
+++ b/src/inhibitor.c
@@ -54,6 +54,10 @@ bool inhibitor_init(struct shortcuts_inhibitor* self, struct wl_surface* surface
 
 	self->surface = surface;
 
+	struct shortcuts_seat_inhibitor* seat_inhibitor;
+	wl_list_for_each(seat_inhibitor, &self->seat_inhibitors, link)
+		inhibitor_inhibit(self, seat_inhibitor->seat);
+
 	return true;
 }
 
@@ -144,6 +148,9 @@ void inhibitor_add_seat(struct shortcuts_inhibitor* self, struct seat* seat)
 
 	seat_inhibitor = seat_inhibitor_new(seat);
 	wl_list_insert(&self->seat_inhibitors, &seat_inhibitor->link);
+
+	if (self->surface)
+		inhibitor_inhibit(self, seat);
 }
 
 void inhibitor_remove_seat(struct shortcuts_inhibitor* self, struct seat* seat)

--- a/src/inhibitor.c
+++ b/src/inhibitor.c
@@ -54,12 +54,6 @@ bool inhibitor_init(struct shortcuts_inhibitor* self, struct wl_surface* surface
 
 	self->surface = surface;
 
-	struct seat* seat;
-	struct seat* tmp;
-
-	wl_list_for_each_safe(seat, tmp, seats, link)
-		inhibitor_add_seat(self, seat);
-
 	return true;
 }
 

--- a/src/inhibitor.c
+++ b/src/inhibitor.c
@@ -6,6 +6,25 @@
 #include <wayland-client.h>
 #include <assert.h>
 
+void inhibitor_active(void *data,
+		struct zwp_keyboard_shortcuts_inhibitor_v1 *zwp_keyboard_shortcuts_inhibitor_v1)
+{
+	struct shortcuts_seat_inhibitor* seat_inhibitor = data;
+	seat_inhibitor->active = true;
+}
+
+void inhibitor_inactive(void *data,
+		struct zwp_keyboard_shortcuts_inhibitor_v1 *zwp_keyboard_shortcuts_inhibitor_v1)
+{
+	struct shortcuts_seat_inhibitor* seat_inhibitor = data;
+	seat_inhibitor->active = false;
+}
+
+static struct zwp_keyboard_shortcuts_inhibitor_v1_listener inhibitor_listener = {
+	.active = inhibitor_active,
+	.inactive = inhibitor_inactive,
+};
+
 struct shortcuts_inhibitor* inhibitor_new(struct zwp_keyboard_shortcuts_inhibit_manager_v1* manager)
 {
 	struct shortcuts_inhibitor* self = calloc(1, sizeof(*self));
@@ -27,6 +46,7 @@ struct shortcuts_seat_inhibitor* seat_inhibitor_new(struct seat* seat)
 
 	self->seat = seat;
 	self->inhibitor = NULL;
+	self->active = true;
 
 	return self;
 }
@@ -107,8 +127,12 @@ void inhibitor_inhibit(struct shortcuts_inhibitor* self, struct seat* seat)
 	struct shortcuts_seat_inhibitor* seat_inhibitor = seat_inhibitor_find_by_seat(&self->seat_inhibitors, seat);
 	assert(seat_inhibitor);
 
+	if (!seat_inhibitor->active)
+		return;
+
 	seat_inhibitor->inhibitor = zwp_keyboard_shortcuts_inhibit_manager_v1_inhibit_shortcuts(
 			self->manager, self->surface, seat_inhibitor->seat->wl_seat);
+	zwp_keyboard_shortcuts_inhibitor_v1_add_listener(seat_inhibitor->inhibitor, &inhibitor_listener, seat_inhibitor);
 }
 
 void inhibitor_release(struct shortcuts_inhibitor* self, struct seat* seat)
@@ -120,6 +144,9 @@ void inhibitor_release(struct shortcuts_inhibitor* self, struct seat* seat)
 
 	struct shortcuts_seat_inhibitor* seat_inhibitor = seat_inhibitor_find_by_seat(&self->seat_inhibitors, seat);
 	assert(seat_inhibitor);
+
+	if (!seat_inhibitor->active)
+		return;
 
 	zwp_keyboard_shortcuts_inhibitor_v1_destroy(seat_inhibitor->inhibitor);
 	seat_inhibitor->inhibitor = NULL;

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -23,10 +23,7 @@
 #include <xkbcommon/xkbcommon.h>
 #include <linux/input-event-codes.h>
 
-#include "inhibitor.h"
 #include "keyboard.h"
-
-extern struct shortcuts_inhibitor* inhibitor;
 
 enum keyboard_led_state {
 	KEYBOARD_LED_SCROLL_LOCK = 1 << 0,
@@ -90,7 +87,6 @@ void keyboard_destroy(struct keyboard* self)
 	xkb_context_unref(self->context);
 	wl_keyboard_destroy(self->wl_keyboard);
 	pressed_keys_destroy(&self->pressed_keys);
-	inhibitor_destroy(inhibitor);
 	free(self);
 }
 
@@ -183,8 +179,6 @@ static void keyboard_enter(void* data, struct wl_keyboard* wl_keyboard,
 		keyboard_collection_find_wl_keyboard(collection, wl_keyboard);
 	keyboard->waiting_for_modifiers = true;
 
-	inhibitor_inhibit(inhibitor, keyboard->seat);
-
 	uint32_t* key;
 	wl_array_for_each(key, keys) {
 		handle_key(data, keyboard, *key + 8, XKB_KEY_DOWN);
@@ -197,8 +191,6 @@ static void keyboard_leave(void* data, struct wl_keyboard* wl_keyboard,
 	struct keyboard_collection* collection = data;
 	struct keyboard* keyboard =
 		keyboard_collection_find_wl_keyboard(collection, wl_keyboard);
-
-	inhibitor_release(inhibitor, keyboard->seat);
 
 	struct pressed_key* pressed_key;
 	struct pressed_key* tmp;

--- a/src/pointer.c
+++ b/src/pointer.c
@@ -18,18 +18,17 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <assert.h>
+#include <stdbool.h>
 #include <wayland-client.h>
 #include <wayland-cursor.h>
 #include <linux/input-event-codes.h>
 
-#include "inhibitor.h"
 #include "pointer.h"
 
 #define STEP_SIZE 15.0
 
 extern struct wl_shm* wl_shm;
 extern struct wl_compositor* wl_compositor;
-extern struct shortcuts_inhibitor* inhibitor;
 
 static struct wl_cursor_theme* pointer_load_cursor_theme(void)
 {
@@ -73,7 +72,6 @@ void pointer_destroy(struct pointer* self)
 	if (self->cursor_theme)
 		wl_cursor_theme_destroy(self->cursor_theme);
 	wl_surface_destroy(self->cursor_surface);
-	inhibitor_destroy(inhibitor);
 	free(self);
 }
 
@@ -171,7 +169,6 @@ static void pointer_enter(void* data, struct wl_pointer* wl_pointer,
 	pointer->serial = serial;
 
 	pointer_update_cursor(pointer);
-	inhibitor_inhibit(inhibitor, pointer->seat);
 }
 
 static void pointer_leave(void* data, struct wl_pointer* wl_pointer,
@@ -187,7 +184,6 @@ static void pointer_leave(void* data, struct wl_pointer* wl_pointer,
 		return;
 
 	pointer->serial = serial;
-	inhibitor_release(inhibitor, pointer->seat);
 }
 
 static void pointer_motion(void* data, struct wl_pointer* wl_pointer,


### PR DESCRIPTION
follow-up of https://github.com/any1/wlvncc/pull/54

With those changes, the compositor can freely make our inhibitors inactive permanently. We should then stop managing them with F12, until the user activate them back.

This also solve minor issues.