### PR TITLE
Improve shortcut inhibitors

### DIFF
--- a/include/inhibitor.h
+++ b/include/inhibitor.h
@@ -17,6 +17,7 @@ struct shortcuts_seat_inhibitor {
 	struct wl_list link;
 
 	struct seat* seat;
+	bool active;
 
 	struct zwp_keyboard_shortcuts_inhibitor_v1* inhibitor;
 };

--- a/src/inhibitor.c
+++ b/src/inhibitor.c
@@ -54,6 +54,10 @@ bool inhibitor_init(struct shortcuts_inhibitor* self, struct wl_surface* surface
 
 	self->surface = surface;
 
+	struct shortcuts_seat_inhibitor* seat_inhibitor;
+	wl_list_for_each(seat_inhibitor, &self->seat_inhibitors, link)
+		inhibitor_inhibit(self, seat_inhibitor->seat);
+
 	return true;
 }
 
@@ -144,6 +148,9 @@ void inhibitor_add_seat(struct shortcuts_inhibitor* self, struct seat* seat)
 
 	seat_inhibitor = seat_inhibitor_new(seat);
 	wl_list_insert(&self->seat_inhibitors, &seat_inhibitor->link);
+
+	if (self->surface)
+		inhibitor_inhibit(self, seat);
 }
 
 void inhibitor_remove_seat(struct shortcuts_inhibitor* self, struct seat* seat)

--- a/src/inhibitor.c
+++ b/src/inhibitor.c
@@ -54,12 +54,6 @@ bool inhibitor_init(struct shortcuts_inhibitor* self, struct wl_surface* surface
 
 	self->surface = surface;
 
-	struct seat* seat;
-	struct seat* tmp;
-
-	wl_list_for_each_safe(seat, tmp, seats, link)
-		inhibitor_add_seat(self, seat);
-
 	return true;
 }
 

--- a/src/pointer.c
+++ b/src/pointer.c
@@ -18,18 +18,17 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <assert.h>
+#include <stdbool.h>
 #include <wayland-client.h>
 #include <wayland-cursor.h>
 #include <linux/input-event-codes.h>
 
-#include "inhibitor.h"
 #include "pointer.h"
 
 #define STEP_SIZE 15.0
 
 extern struct wl_shm* wl_shm;
 extern struct wl_compositor* wl_compositor;
-extern struct shortcuts_inhibitor* inhibitor;
 
 static struct wl_cursor_theme* pointer_load_cursor_theme(void)
 {
@@ -73,7 +72,6 @@ void pointer_destroy(struct pointer* self)
 	if (self->cursor_theme)
 		wl_cursor_theme_destroy(self->cursor_theme);
 	wl_surface_destroy(self->cursor_surface);
-	inhibitor_destroy(inhibitor);
 	free(self);
 }
 
@@ -171,7 +169,6 @@ static void pointer_enter(void* data, struct wl_pointer* wl_pointer,
 	pointer->serial = serial;
 
 	pointer_update_cursor(pointer);
-	inhibitor_inhibit(inhibitor, pointer->seat);
 }
 
 static void pointer_leave(void* data, struct wl_pointer* wl_pointer,
@@ -187,7 +184,6 @@ static void pointer_leave(void* data, struct wl_pointer* wl_pointer,
 		return;
 
 	pointer->serial = serial;
-	inhibitor_release(inhibitor, pointer->seat);
 }
 
 static void pointer_motion(void* data, struct wl_pointer* wl_pointer,


### PR DESCRIPTION
This is a followup of the three closed MR:

https://github.com/any1/wlvncc/pull/55
https://github.com/any1/wlvncc/pull/54
https://github.com/any1/wlvncc/pull/53

This make the shortcut inhibitor to works on the whole top-level surface, not just the inner surface. The current behavior feels really wrong. It even looks like it is bugged, in cases some of the internal buffer is also black (looking at a video with an aspect ratio not fitting).

On the first place, I did this because of the F12 toggle key. Because moving the pointer between the bg surface and the inner surface was deactivating/reactivating the inhibitors. So to improve this, we have to change this too.

For this, we have to change how we manage the inhibitors. We stop creating and destroying them as we enter and leave the surfaces. We create them once, then the user can toggle them with F12, or their compositor dedicated keybinds. The toggling behaviors are much more consistent and predictable to the user.  We also deactivate F12 completely when the compositor make them inactive itself.

As an example, here my new Sway config entry to toggle the inhibitors with `$mod+Escape`:

```
bindsym --inhibited $mod+Escape seat - shortcuts_inhibitor toggle
```