### PR TITLE
Refactor the rendering loop

### DIFF
--- a/include/buffer.h
+++ b/include/buffer.h
@@ -38,7 +38,6 @@ struct buffer {
 	uint32_t format;
 	struct wl_buffer* wl_buffer;
 	bool is_attached;
-	bool please_clean_up;
 	struct pixman_region16 damage;
 
 	// wl_shm:

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -37,7 +37,6 @@ struct buffer {
 	size_t size;
 	uint32_t format;
 	struct wl_buffer* wl_buffer;
-	bool is_attached;
 	struct pixman_region16 damage;
 
 	// wl_shm:

--- a/src/main.c
+++ b/src/main.c
@@ -84,8 +84,6 @@ struct window {
 
 	struct vnc_client* vnc;
 	void* vnc_fb;
-
-	bool is_frame_committed;
 };
 
 struct format_table_entry {
@@ -94,7 +92,6 @@ struct format_table_entry {
 	uint64_t modifier;
 } __attribute__((packed));
 
-static void register_frame_callback(void);
 
 static struct wl_display* wl_display;
 static struct wl_registry* wl_registry;
@@ -387,7 +384,6 @@ static int init_signal_handler(void)
 static void window_attach(struct window* w)
 {
 	wl_surface_attach(w->wl_bg_surface, w->wl_bg_buffer, 0, 0);
-	w->back_buffer->is_attached = true;
 	wl_surface_attach(w->wl_surface, w->back_buffer->wl_buffer, 0, 0);
 }
 
@@ -854,59 +850,26 @@ static void window_damage_region(struct window* w,
 	}
 }
 
-static void render_from_vnc(void)
+void on_vnc_client_update_fb(struct vnc_client* client)
 {
+	get_frame_damage(window->vnc, &window->current_damage);
 	if (!pixman_region_not_empty(&window->current_damage) &&
 			window->vnc->n_av_frames == 0)
 		return;
 
-	if (window->is_frame_committed)
-		return;
-
-	if (window->back_buffer->is_attached)
-		fprintf(stderr, "Oops, back-buffer is still attached.\n");
-
-	window_attach(window);
-
 	apply_buffer_damage(&window->current_damage);
-	window_damage_region(window, &window->current_damage);
 
 	window_transfer_pixels(window);
 
-	window->is_frame_committed = true;
-	register_frame_callback();
-
+	window_attach(window);
+	window_damage_region(window, &window->current_damage);
 	window_commit(window);
 	window_swap(window);
 
 	pixman_region_clear(&window->current_damage);
+
 	vnc_client_clear_av_frames(window->vnc);
-}
-
-void on_vnc_client_update_fb(struct vnc_client* client)
-{
-	get_frame_damage(window->vnc, &window->current_damage);
-	render_from_vnc();
-}
-
-static void handle_frame_callback(void* data, struct wl_callback* callback,
-		uint32_t time)
-{
-	wl_callback_destroy(callback);
-	window->is_frame_committed = false;
-
-	if (!window->vnc->is_updating)
-		render_from_vnc();
-}
-
-static const struct wl_callback_listener frame_listener = {
-	.done = handle_frame_callback
-};
-
-static void register_frame_callback(void)
-{
-	struct wl_callback* callback = wl_surface_frame(window->wl_surface);
-	wl_callback_add_listener(callback, &frame_listener, NULL);
+	window_commit(window);
 }
 
 void on_vnc_client_event(void* obj)


### PR DESCRIPTION
Simplify the rendering loop

I'm not really sure if this change bring something noticeable for the
user. But at least, this is theorically more robust, and the code
is more simple.

Drop outdated is_attached, please_clean_up, is_frame_committed.

We can now drop the please_clean_up thing completely. This was necessary
before, when we was destroying and re-creating buffers when the surface
size changed. But now that the buffers keep their dimensions always, we
don't need this anymore.

Also, I dropped the tripple buffer, and just use two of them. Is there
a reason to use three in the first place?

Dropped the frame callback completely. There now is no value to keep it.