### PR TITLE
Add support for explicit linear dmabuf modifiers

### DIFF
--- a/include/buffer.h
+++ b/include/buffer.h
@@ -36,6 +36,7 @@ struct buffer {
 	int width, height;
 	size_t size;
 	uint32_t format;
+	uint64_t modifier;
 	struct wl_buffer* wl_buffer;
 	bool is_attached;
 	bool please_clean_up;
@@ -50,5 +51,5 @@ struct buffer {
 };
 
 struct buffer* buffer_create_shm(int width, int height, int stride, uint32_t format);
-struct buffer* buffer_create_dmabuf(int width, int height, uint32_t format);
+struct buffer* buffer_create_dmabuf(int width, int height, uint32_t format, uint64_t modifier);
 void buffer_destroy(struct buffer* self);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -24,6 +24,7 @@
 #include <wayland-client.h>
 #include <gbm.h>
 #include <assert.h>
+#include <drm_fourcc.h>
 
 /* Origin: main.c */
 extern struct wl_shm* wl_shm;
@@ -98,7 +99,7 @@ failure:
 	return NULL;
 }
 
-struct buffer* buffer_create_dmabuf(int width, int height, uint32_t format)
+struct buffer* buffer_create_dmabuf(int width, int height, uint32_t format, uint64_t modifier)
 {
 	assert(gbm_device && zwp_linux_dmabuf_v1);
 
@@ -110,11 +111,18 @@ struct buffer* buffer_create_dmabuf(int width, int height, uint32_t format)
 	self->width = width;
 	self->height = height;
 	self->format = format;
+	self->modifier = modifier;
 
 	pixman_region_init_rect(&self->damage, 0, 0, width, height);
 
-	self->bo = gbm_bo_create(gbm_device, width, height, format,
-			GBM_BO_USE_RENDERING);
+	if (modifier == DRM_FORMAT_MOD_INVALID) {
+		self->bo = gbm_bo_create(gbm_device, width, height, format,
+				GBM_BO_USE_RENDERING);
+	} else {
+		int count = gbm_device_get_format_modifier_plane_count(gbm_device, format, self->modifier);
+		self->bo = gbm_bo_create_with_modifiers2(gbm_device, width, height, format, &self->modifier, count,
+				GBM_BO_USE_RENDERING);
+	};
 	if (!self->bo)
 		goto bo_failure;
 

--- a/src/main.c
+++ b/src/main.c
@@ -120,6 +120,7 @@ static bool shortcut_inhibit = false;
 
 static uint32_t shm_format = DRM_FORMAT_INVALID;
 static uint32_t dmabuf_format = DRM_FORMAT_INVALID;
+static uint64_t dmabuf_modifier = DRM_FORMAT_MOD_INVALID;
 
 static bool do_run = true;
 
@@ -314,8 +315,12 @@ static void handle_tranche_formats(void* data,
 		switch (format_table[*index].format) {
 		case DRM_FORMAT_XRGB8888:
 		case DRM_FORMAT_XBGR8888:
-			if (format_table[*index].modifier == DRM_FORMAT_MOD_INVALID)
+			switch (format_table[*index].modifier) {
+			case DRM_FORMAT_MOD_INVALID:
+			case DRM_FORMAT_MOD_LINEAR:
 				dmabuf_format = format_table[*index].format;
+				dmabuf_modifier = format_table[*index].modifier;
+			}
 		}
 	}
 }
@@ -814,7 +819,7 @@ int on_vnc_client_alloc_fb(struct vnc_client* client)
 
 	for (int i = 0; i < 3; ++i) {
 		window->buffers[i] = have_egl
-			? buffer_create_dmabuf(width, height, dmabuf_format)
+			? buffer_create_dmabuf(width, height, dmabuf_format, dmabuf_modifier)
 			: buffer_create_shm(width, height, 4 * width, shm_format);
 	}
 	window->back_buffer = window->buffers[0];


### PR DESCRIPTION
Apparently sometime there is no available implicit modifier at all, making EGl unavailable. Supporting explicit linear fix open-h264 usage here.

fix: https://github.com/any1/wlvncc/issues/68